### PR TITLE
Add storage and interfaces repos to report generation

### DIFF
--- a/.github/workflows/report_per_repo.yml
+++ b/.github/workflows/report_per_repo.yml
@@ -44,6 +44,10 @@ jobs:
             sw-name: starter-kit-lsaai-mock
           - repository: GenomicDataInfrastructure/starter-kit-lsaai
             sw-name: starter-kit-lsaai
+          - repository: neicnordic/sensitive-data-archive
+            sw-name: neicnordic/sensitive-data-archive
+          - repository: NBISweden/sda-cli
+            sw-name: sda-cli
             
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The storage-and-interfaces product is using the sensitive-data-archive software stack from NeIC and also the sda-cli from NBIS.